### PR TITLE
Allow nulls for aggregate results

### DIFF
--- a/revolsys-core/src/main/java/com/revolsys/record/query/Case.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/query/Case.java
@@ -1,0 +1,85 @@
+package com.revolsys.record.query;
+
+import java.sql.PreparedStatement;
+
+import com.revolsys.collection.list.ListEx;
+import com.revolsys.collection.list.Lists;
+import com.revolsys.collection.map.MapEx;
+import com.revolsys.record.schema.RecordStore;
+
+public class Case implements QueryValue {
+
+  public record When(Condition condition, QueryValue value) {
+  }
+
+  private final ListEx<When> whens = Lists.newArray();
+
+  private QueryValue elseValue;
+
+  public Case addWhen(final Condition condition, final QueryValue value) {
+    this.whens.add(new When(condition, value));
+    return this;
+  }
+
+  @Override
+  public void appendDefaultSql(final QueryStatement statement, final RecordStore recordStore,
+    final SqlAppendable sql) {
+    sql.append("CASE");
+
+    this.whens.forEach(when -> {
+      sql.append(" WHEN ");
+      when.condition.appendDefaultSql(statement, recordStore, sql);
+      sql.append(" THEN ");
+      when.value.appendDefaultSql(statement, recordStore, sql);
+    });
+
+    if (this.elseValue != null) {
+      sql.append(" ELSE ");
+      this.elseValue.appendDefaultSql(statement, recordStore, sql);
+    }
+    sql.append(" END");
+  }
+
+  @Override
+  public int appendParameters(int index, final PreparedStatement statement) {
+    for (final var when : this.whens) {
+      index = when.condition.appendParameters(index, statement);
+      index = when.value.appendParameters(index, statement);
+    }
+    if (this.elseValue != null) {
+      index = this.elseValue.appendParameters(index, statement);
+    }
+    return index;
+  }
+
+  @Override
+  public QueryValue clone(final TableReference oldTable, final TableReference newTable) {
+    final Case clone = new Case();
+    this.whens.forEach(when -> {
+      clone.addWhen(when.condition.clone(oldTable, newTable), when.value.clone(oldTable, newTable));
+    });
+    if (this.elseValue != null) {
+      clone.setElse(this.elseValue.clone(oldTable, newTable));
+    }
+    return clone;
+  }
+
+  @Override
+  public <V> V getValue(final MapEx record) {
+    for (final var when : this.whens) {
+      if (when.condition.test(record)) {
+        return when.value.getValue(record);
+      }
+    }
+    if (this.elseValue != null) {
+      return this.elseValue.getValue(record);
+    } else {
+      return null;
+    }
+  }
+
+  public Case setElse(final QueryValue elseValue) {
+    this.elseValue = elseValue;
+    return this;
+  }
+}

--- a/revolsys-core/src/main/java/com/revolsys/record/query/Case.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/query/Case.java
@@ -16,7 +16,7 @@ public class Case implements QueryValue {
 
   private QueryValue elseValue;
 
-  public Case addWhen(final Condition condition, final QueryValue value) {
+  public Case when(final Condition condition, final QueryValue value) {
     this.whens.add(new When(condition, value));
     return this;
   }
@@ -56,10 +56,10 @@ public class Case implements QueryValue {
   public QueryValue clone(final TableReference oldTable, final TableReference newTable) {
     final Case clone = new Case();
     this.whens.forEach(when -> {
-      clone.addWhen(when.condition.clone(oldTable, newTable), when.value.clone(oldTable, newTable));
+      clone.when(when.condition.clone(oldTable, newTable), when.value.clone(oldTable, newTable));
     });
     if (this.elseValue != null) {
-      clone.setElse(this.elseValue.clone(oldTable, newTable));
+      clone.elseValue(this.elseValue.clone(oldTable, newTable));
     }
     return clone;
   }
@@ -78,7 +78,7 @@ public class Case implements QueryValue {
     }
   }
 
-  public Case setElse(final QueryValue elseValue) {
+  public Case elseValue(final QueryValue elseValue) {
     this.elseValue = elseValue;
     return this;
   }

--- a/revolsys-core/src/main/java/com/revolsys/record/query/NullValue.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/query/NullValue.java
@@ -1,0 +1,35 @@
+package com.revolsys.record.query;
+
+import java.sql.PreparedStatement;
+
+import com.revolsys.collection.map.MapEx;
+import com.revolsys.record.schema.RecordStore;
+
+public class NullValue implements QueryValue {
+
+  public static final NullValue INSTANCE = new NullValue();
+
+  private NullValue() {
+  }
+
+  @Override
+  public void appendDefaultSql(final QueryStatement statement, final RecordStore recordStore,
+    final SqlAppendable sql) {
+    sql.append("NULL");
+  }
+
+  @Override
+  public int appendParameters(final int index, final PreparedStatement statement) {
+    return index;
+  }
+
+  @Override
+  public QueryValue clone(final TableReference oldTable, final TableReference newTable) {
+    return this;
+  }
+
+  @Override
+  public <V> V getValue(final MapEx record) {
+    return null;
+  }
+}

--- a/revolsys-core/src/main/java/com/revolsys/record/query/Q.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/query/Q.java
@@ -515,6 +515,10 @@ public class Q {
     return not(exists(expression));
   }
 
+  public static NullValue nullValue() {
+    return NullValue.INSTANCE;
+  }
+
   public static Or or(final Condition... conditions) {
     final List<Condition> list = Arrays.asList(conditions);
     return or(list);

--- a/revolsys-core/src/main/java/com/revolsys/record/schema/AbstractTableRecordStore.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/schema/AbstractTableRecordStore.java
@@ -40,6 +40,7 @@ import com.revolsys.record.Record;
 import com.revolsys.record.code.CodeTable;
 import com.revolsys.record.io.RecordReader;
 import com.revolsys.record.io.RecordWriter;
+import com.revolsys.record.query.Case;
 import com.revolsys.record.query.Cast;
 import com.revolsys.record.query.Column;
 import com.revolsys.record.query.ColumnReference;
@@ -803,15 +804,6 @@ public class AbstractTableRecordStore implements RecordDefinitionProxy {
       alias = parts[2];
     }
 
-    boolean filterInvalidValues = true;
-    if (parts.length > 3) {
-      final var option = parts[3];
-      final var prefix = "filterInvalidValues=";
-      if (option.startsWith(prefix)) {
-        filterInvalidValues = Boolean.parseBoolean(option.substring(prefix.length()));
-      }
-    }
-
     return switch (functionName) {
       case "count": {
         yield Count.STAR.toAlias(alias);
@@ -831,16 +823,14 @@ public class AbstractTableRecordStore implements RecordDefinitionProxy {
           columnClass = fieldDefinition.getTypeClass();
         }
         if (JsonType.class.isAssignableFrom(columnClass)) {
-          if (filterInvalidValues) {
-            query.and(Q.equal(F.function("jsonb_typeof", field), "number"));
-          }
-          field = field.toCast("decimal");
+          field = new Case()
+            .addWhen(Q.equal(F.function("jsonb_typeof", field), "number"), field.toCast("decimal"))
+            .setElse(Value.newValue(null));
         } else if (!Number.class.isAssignableFrom(columnClass)) {
-          if (filterInvalidValues) {
-            query.and(
-              Q.equal(F.function("pg_input_is_valid", field, Value.newValue("decimal")), true));
-          }
-          field = field.toCast("decimal");
+          field = new Case()
+            .addWhen(Q.equal(F.function("pg_input_is_valid", field, Q.literal("decimal")), true),
+              field.toCast("decimal"))
+            .setElse(Value.newValue(null));
         }
         yield F.function(functionName, field)
           .toAlias(alias);

--- a/revolsys-core/src/main/java/com/revolsys/record/schema/AbstractTableRecordStore.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/schema/AbstractTableRecordStore.java
@@ -803,6 +803,15 @@ public class AbstractTableRecordStore implements RecordDefinitionProxy {
       alias = parts[2];
     }
 
+    boolean filterInvalidValues = true;
+    if (parts.length > 3) {
+      final var option = parts[3];
+      final var prefix = "filterInvalidValues=";
+      if (option.startsWith(prefix)) {
+        filterInvalidValues = Boolean.parseBoolean(option.substring(prefix.length()));
+      }
+    }
+
     return switch (functionName) {
       case "count": {
         yield Count.STAR.toAlias(alias);
@@ -822,11 +831,15 @@ public class AbstractTableRecordStore implements RecordDefinitionProxy {
           columnClass = fieldDefinition.getTypeClass();
         }
         if (JsonType.class.isAssignableFrom(columnClass)) {
-          query.and(Q.equal(F.function("jsonb_typeof", field), "number"));
+          if (filterInvalidValues) {
+            query.and(Q.equal(F.function("jsonb_typeof", field), "number"));
+          }
           field = field.toCast("decimal");
         } else if (!Number.class.isAssignableFrom(columnClass)) {
-          query
-            .and(Q.equal(F.function("pg_input_is_valid", field, Value.newValue("decimal")), true));
+          if (filterInvalidValues) {
+            query.and(
+              Q.equal(F.function("pg_input_is_valid", field, Value.newValue("decimal")), true));
+          }
           field = field.toCast("decimal");
         }
         yield F.function(functionName, field)

--- a/revolsys-core/src/main/java/com/revolsys/record/schema/AbstractTableRecordStore.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/schema/AbstractTableRecordStore.java
@@ -823,14 +823,16 @@ public class AbstractTableRecordStore implements RecordDefinitionProxy {
           columnClass = fieldDefinition.getTypeClass();
         }
         if (JsonType.class.isAssignableFrom(columnClass)) {
+          if (field instanceof final JsonValue jsonValue) {
+            jsonValue.setText(true);
+          }
+        }
+
+        if (!Number.class.isAssignableFrom(columnClass)) {
           field = new Case()
-            .addWhen(Q.equal(F.function("jsonb_typeof", field), "number"), field.toCast("decimal"))
-            .setElse(Value.newValue(null));
-        } else if (!Number.class.isAssignableFrom(columnClass)) {
-          field = new Case()
-            .addWhen(Q.equal(F.function("pg_input_is_valid", field, Q.literal("decimal")), true),
+            .when(Q.equal(F.function("pg_input_is_valid", field, Q.literal("decimal")), true),
               field.toCast("decimal"))
-            .setElse(Value.newValue(null));
+            .elseValue(Q.nullValue());
         }
         yield F.function(functionName, field)
           .toAlias(alias);


### PR DESCRIPTION
When > 1 metrics are added to the chart, no results are returned from the backend if either query returns null for a row. This change is to return data regardless of whether the row has valid values so that the information is still displayed on the chart.